### PR TITLE
fix(fix-compatibility): fixed design issues incompatible with Safari

### DIFF
--- a/src/components/navbar/Navbar.css
+++ b/src/components/navbar/Navbar.css
@@ -29,26 +29,15 @@
   display: flex;
   flex-direction: row;
   align-items: center;
-  margin-left: auto;
-  margin-right: 2rem;
-  gap: 2em;
-}
-
-.navbar button {     
-  background-color: Transparent;
-  background-repeat:no-repeat;
-  border: none;
-  cursor: pointer;
-  overflow: hidden;        
+  margin: -1em 2em -1em auto
 }
 
 .burger-menu {
   display: none;
   width: 3rem;
   height: 3rem;
-  margin-left: auto;
-  margin-right: 1rem;
-  gap: 0.3rem;
+  margin: 0 1rem 0 auto;
+  cursor: pointer;
 }
 
 .burger-menu:hover .burger-menu-line{
@@ -68,6 +57,8 @@
   width: 70%;
   height: 0.2rem;
   background-color: #bfc0c0;
+  margin-top: 0.15em;
+  margin-bottom: 0.15em;
   transition: all ease-in-out 250ms;
 }
 
@@ -76,7 +67,7 @@
   width: 70%;
   height: 0.2rem;
   background-color: #bfc0c0;
-  transform: rotate(45deg) translate(0.2em, 0.5em);
+  transform: rotate(45deg) translate(0em, 0.11em);
   transition: all ease-in-out 750ms;
 }
 
@@ -90,7 +81,7 @@
   width: 70%;
   height: 0.2rem;
   background-color: #bfc0c0;
-  transform: rotate(-45deg) translate(0.2em, -0.5em);
+  transform: rotate(-45deg) translate(0em, -0.11em);
   transition: all ease-in-out 750ms;
 }
 
@@ -115,6 +106,7 @@
   height: 100%;
   position: relative;
   transition: all ease-in-out 250ms;
+  margin: 1rem;
 }
 
 .nav-link:hover {
@@ -145,7 +137,6 @@
   top: 0;
   width: 100%;
   height: 18rem;
-  gap: 0.2rem;
   padding-top: 1.2em;
   padding-bottom: 1.2em;
   align-items: center;
@@ -171,7 +162,6 @@
   top: 0;
   width: 100%;
   height: 18rem;
-  gap: 0.2rem;
   padding-top: 1.2em;
   padding-bottom: 1.2em;
   align-items: center;

--- a/src/components/navbar/Navbar.js
+++ b/src/components/navbar/Navbar.js
@@ -36,14 +36,14 @@ class Navbar extends React.Component {
               <a href='#' className='nav-link'>Projects</a>
               <a href='#' className='nav-link'>Contact</a>
           </div>
-          <button className='burger-menu' onClick={this.handleBurgerClick}>
+          <div className='burger-menu' onClick={this.handleBurgerClick}>
             <span className={this.state.burgerToggle ? 'burger-line-rotate-top' : 
                             'burger-menu-line'}></span>
             <span className={this.state.burgerToggle ? 'burger-line-invisible' : 
                             'burger-menu-line'}></span>
             <span className={this.state.burgerToggle ? 'burger-line-rotate-bottom' : 
                             'burger-menu-line'}></span>
-          </button>
+          </div>
           <div className={this.state.burgerToggle ? 'navbar-dropdown' : 'navbar-dropdown-off'}>
             <a href='#' className='nav-link' onClick={this.toggleBurgerOff}>About</a>
             <a href='#' className='nav-link' onClick={this.toggleBurgerOff}>Timeline</a>


### PR DESCRIPTION
Replaced all the `gap` properties in all `flexbox` divs with manually set `margin`s that simulate its effect. This is because `gap` is not supported for versions of Safari that are earlier than 14.1. Also changed the burger menu to be a regular `div` rather than a `button` since it seemed to not be visible as a button on Safari 13.0.4, but also remains consistent with the fact that `Flipcards` are also not set as `button` tag.